### PR TITLE
Allow option to remove host tag for dogstatsd metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -523,6 +523,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             if config.has_option('Main', 'statsd_forward_port'):
                 agentConfig['statsd_forward_port'] = int(config.get('Main', 'statsd_forward_port'))
 
+        if config.has_option("Main", "dogstatsd_remove_host_tag"):
+            agentConfig["dogstatsd_remove_host_tag"] = _is_affirmative(config.get("Main", "dogstatsd_remove_host_tag"))
+        else:
+            agentConfig["dogstatsd_remove_host_tag"] = False
+
         # Optional config
         # FIXME not the prettiest code ever...
         if config.has_option('Main', 'use_mount'):

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -178,6 +178,11 @@ gce_updated_hostname: yes
 # to https://app.datadoghq.com.
 # dogstatsd_target: http://localhost:17123
 
+# Enabling this will send a dummy host: tag for every metric submitted to dogstatsd.
+# This is useful for trying to reduce the number of tags for a given metric. More information
+# here: https://help.datadoghq.com/hc/en-us/articles/218349043-How-to-remove-the-host-tag-when-submitting-metrics-via-dogstatsD
+# dogstatsd_remove_host_tag: false
+#
 # If you want to forward every packet received by the dogstatsd server
 # to another statsd server, uncomment these lines.
 # WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,


### PR DESCRIPTION
This change adds a config option (`dogstatsd_remove_host_tag`) which when enabled will force the `dogstatsd` daemon to report all metrics with an added `host:` tag. This is done in an effort to reduce the cardinality on custom metrics at the expense of being able to break the metrics down at
the host level.

Note that this was built from the `5.19.0` tag.

**Testing**
- [x] Default config (commented out, default to `False`): tags are not modified
- [x] Set to false in config: tags are not modified
- [x] Set to true in config
  - [x] Informational log line indicating host tags will not be sent
    > 2017-11-14 19:08:03,625 | INFO | dd.dogstatsd | dogstatsd(dogstatsd.py:236) | Not sending distinct host tags for every metric
  - [x] Tags are modified
```
'BEFORE'
[('crl8.test.gauge', 'gauge', None, [(1510687300.0, 10)]),
 ('crl8.test.timer.max', 'gauge', None, [(1510687310.0, 10)]),
 ('crl8.test.timer.median', 'gauge', None, [(1510687310.0, 10)]),
 ('crl8.test.timer.avg', 'gauge', None, [(1510687310.0, 10.0)]),
 ('crl8.test.timer.count', 'rate', None, [(1510687310.0, 0.1)]),
 ('crl8.test.timer.95percentile', 'gauge', None, [(1510687310.0, 10)]),
 ('crl8.test.gauge', 'gauge', ('baz:qux', 'foo:bar'), [(1510687310.0, 10)]),
 ('crl8.test.counter', 'rate', None, [(1510687310.0, 1.0)]),
 ('crl8.test.gauge', 'gauge', ('foo:bar',), [(1510687310.0, 10)])]
'AFTER'
[('crl8.test.gauge', 'gauge', ('host:',), [(1510687300.0, 10)]),
 ('crl8.test.timer.max', 'gauge', ('host:',), [(1510687310.0, 10)]),
 ('crl8.test.timer.median', 'gauge', ('host:',), [(1510687310.0, 10)]),
 ('crl8.test.timer.avg', 'gauge', ('host:',), [(1510687310.0, 10.0)]),
 ('crl8.test.timer.count', 'rate', ('host:',), [(1510687310.0, 0.1)]),
 ('crl8.test.timer.95percentile', 'gauge', ('host:',), [(1510687310.0, 10)]),
 ('crl8.test.gauge',
  'gauge',
  ('baz:qux', 'foo:bar', 'host:'),
  [(1510687310.0, 10)]),
 ('crl8.test.counter', 'rate', ('host:',), [(1510687310.0, 1.0)]),
 ('crl8.test.gauge', 'gauge', ('foo:bar', 'host:'), [(1510687310.0, 10)])]
```