### PR TITLE
Implement basic blacklist for tags sent via dogstatsd

### DIFF
--- a/config.py
+++ b/config.py
@@ -528,6 +528,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         else:
             agentConfig["dogstatsd_remove_host_tag"] = False
 
+        if config.has_option("Main", "dogstatsd_blacklist_tags_re"):
+            agentConfig["dogstatsd_blacklist_tags_re"] = re.compile(config.get("Main", "dogstatsd_blacklist_tags_re"))
+        else:
+            agentConfig["dogstatsd_blacklist_tags_re"] = None
+
         # Optional config
         # FIXME not the prettiest code ever...
         if config.has_option('Main', 'use_mount'):

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -183,6 +183,9 @@ gce_updated_hostname: yes
 # here: https://help.datadoghq.com/hc/en-us/articles/218349043-How-to-remove-the-host-tag-when-submitting-metrics-via-dogstatsD
 # dogstatsd_remove_host_tag: false
 #
+# Regex to use to filter out unwanted tags.
+# dogstatsd_blacklist_tags_re: .*
+#
 # If you want to forward every packet received by the dogstatsd server
 # to another statsd server, uncomment these lines.
 # WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,


### PR DESCRIPTION
This change adds a config option (`dogstatsd_blacklist_tags_re`) to be used as a regular expression that can filter out unwanted metric tags received via `dogstatsd`. This is another change meant to allow more flexibility in reducing the cardinality on custom metrics.

Note that this was built from the `5.19.0` tag.

**Testing**
- [x] Default config (commented out): tags are not modified
- [x] Set to `.*` in config:
  - [x] Informational log line indicating regex being used
  - [x] All tags dropped
- [x] Set to `.*` in config with `dogstatsd_remove_host_tag` enabled:
  - [x] Informational log line indicating regex being used
  - [x] Only `host:` tags kept
- [x] Set to `.*foo.*` in config with `dogstatsd_remove_host_tag` enabled (see below):
  - [x] All `foo:*` tags dropped
  - [x] `host:` tags kept

I pretty printed the output off the metrics before and after and then ran `diff`d against the results (redundant metrics are snipped out):

```
$ diff -w -U0 orig modd 
--- old	2017-11-28 13:20:18.000000000 -0500
+++ new	2017-11-28 13:20:24.000000000 -0500
@@ -6 +6 @@
-  'tags': None,
+  'tags': ('host:',),
@@ -13 +13 @@
-  'tags': ('foo:bar',),
+  'tags': ('host:',),
@@ -20 +20 @@
-  'tags': ('qux',),
+  'tags': ('qux', 'host:'),
@@ -27 +27 @@
-  'tags': ('bar:baz',),
+  'tags': ('bar:baz', 'host:'),
@@ -90 +90 @@
-  'tags': ('baz:qux',),
+  'tags': ('baz:qux', 'host:'),
```