### PR TITLE
Exclude multiple AWS resource-based tags from metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -523,10 +523,10 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             if config.has_option('Main', 'statsd_forward_port'):
                 agentConfig['statsd_forward_port'] = int(config.get('Main', 'statsd_forward_port'))
 
-        if config.has_option("Main", "dogstatsd_remove_host_tag"):
-            agentConfig["dogstatsd_remove_host_tag"] = _is_affirmative(config.get("Main", "dogstatsd_remove_host_tag"))
+        if config.has_option("Main", "dogstatsd_remove_aws_resource_tags"):
+            agentConfig["dogstatsd_remove_aws_resource_tags"] = _is_affirmative(config.get("Main", "dogstatsd_remove_aws_resource_tags")) || _is_affirmative(config.get("Main", "dogstatsd_remove_host_tag"))
         else:
-            agentConfig["dogstatsd_remove_host_tag"] = False
+            agentConfig["dogstatsd_remove_aws_resource_tags"] = False
 
         if config.has_option("Main", "dogstatsd_blacklist_tags_re"):
             agentConfig["dogstatsd_blacklist_tags_re"] = re.compile(config.get("Main", "dogstatsd_blacklist_tags_re"))

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -178,10 +178,10 @@ gce_updated_hostname: yes
 # to https://app.datadoghq.com.
 # dogstatsd_target: http://localhost:17123
 
-# Enabling this will send a dummy host: tag for every metric submitted to dogstatsd.
-# This is useful for trying to reduce the number of tags for a given metric. More information
+# Enabling this will send an empty value ("") for AWS resource tags submitted to dogstatsd.
+# This is useful for reducing the number of tags for a given metric. More information
 # here: https://help.datadoghq.com/hc/en-us/articles/218349043-How-to-remove-the-host-tag-when-submitting-metrics-via-dogstatsD
-# dogstatsd_remove_host_tag: false
+# dogstatsd_remove_aws_resource_tags: false
 #
 # Regex to use to filter out unwanted tags.
 # dogstatsd_blacklist_tags_re: .*

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -232,8 +232,8 @@ class Reporter(threading.Thread):
         log.info("Reporting to %s every %ss" % (self.api_host, self.interval))
         log.debug("Watchdog enabled: %s" % bool(self.watchdog))
 
-        if self.agent_config["dogstatsd_remove_host_tag"]:
-            log.info("Not sending distinct host tags for every metric")
+        if self.agent_config["dogstatsd_remove_aws_resource_tags"]:
+            log.info("Not sending AWS resource tags for every metric")
 
         if self.agent_config["dogstatsd_blacklist_tags_re"]:
             log.info("Filtering tags with the following regex: {}".format(self.agent_config["dogstatsd_blacklist_tags_re"].pattern))
@@ -365,7 +365,7 @@ class Reporter(threading.Thread):
         """Utility method used to strip out or override any tags on metrics received via
         dogstatsd"""
 
-        if not self.agent_config['dogstatsd_remove_host_tag'] and not self.agent_config['dogstatsd_blacklist_tags_re']:
+        if not self.agent_config['dogstatsd_remove_aws_resource_tags'] and not self.agent_config['dogstatsd_blacklist_tags_re']:
             return metrics
 
         for metric in metrics:
@@ -379,8 +379,8 @@ class Reporter(threading.Thread):
                 r = self.agent_config['dogstatsd_blacklist_tags_re']
                 metric['tags'] = filter(lambda t: not r.match(t), metric['tags'])
 
-            if self.agent_config['dogstatsd_remove_host_tag']:
-                metric['tags'] = metric['tags'] + ('host:',)
+            if self.agent_config['dogstatsd_remove_aws_resource_tags']:
+                metric['tags'] = metric['tags'] + ('autoscaling_group:', 'availability-zone:', 'build_number:', 'elasticbeanstalk:', 'host:', 'image:', 'instance-type:', 'region:', 'security-group:')
 
         return metrics
 


### PR DESCRIPTION
A recent commit added the ability to overwrite the AWS "host" metric with an empty string.
This prevents the "host" field from contributing to the unique custom metrics total count.
This commit expands the AWS resource-based fields that can be excluded and repurposes
the configuration option to exclude multiple AWS resource-based tags instead of just host.